### PR TITLE
Fix --force, fix windows filename issue & introduce --ignore-write-errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+quote_type = single

--- a/cli.js
+++ b/cli.js
@@ -44,6 +44,7 @@ async function main({ inputFile, outputDir, override }) {
       onStart,
       onUpdate,
       onFinish,
+      override,
     });
   } catch (error) {
     progressBar.stop();

--- a/lib/wpress-extract.js
+++ b/lib/wpress-extract.js
@@ -5,6 +5,16 @@ const path = require('path');
 const HEADER_SIZE = 4377; // length of the header
 const HEADER_CHUNK_EOF = Buffer.alloc(HEADER_SIZE); // Empty header used for check if we reached the end
 
+const IS_WIN = process.platform === 'win32';
+
+function convertToValidWindowsFilename(input) {
+  return IS_WIN ? input.replace(/[|\\:*?"<>]/g, '') : input;
+}
+
+function convertToValidWindowsFilepath(input) {
+  return IS_WIN ? input.replace(/[|\\:*?"<>]/g, '') : input;
+}
+
 function isDirEmpty(dirname) {
   return fs.promises.readdir(dirname).then((files) => {
     return files.length === 0;
@@ -40,7 +50,11 @@ async function readHeader(fd) {
 }
 
 async function readBlockToFile(fd, header, outputPath) {
-  const outputFilePath = path.join(outputPath, header.prefix, header.name);
+  const outputFilePath = path.join(
+    outputPath,
+    convertToValidWindowsFilepath(header.prefix),
+    convertToValidWindowsFilename(header.name)
+  );
   fse.ensureDirSync(path.dirname(outputFilePath));
   const outputStream = fs.createWriteStream(outputFilePath);
 
@@ -65,18 +79,9 @@ async function readBlockToFile(fd, header, outputPath) {
   outputStream.close();
 }
 
-module.exports = async function wpExtract({
-  inputFile: _inputFile,
-  outputDir,
-  onStart,
-  onUpdate,
-  onFinish,
-  override,
-}) {
+module.exports = async function wpExtract({ inputFile: _inputFile, outputDir, onStart, onUpdate, onFinish, override }) {
   if (!fs.existsSync(_inputFile)) {
-    throw new Error(
-      `Input file at location "${_inputFile}" could not be found.`
-    );
+    throw new Error(`Input file at location "${_inputFile}" could not be found.`);
   }
 
   if (override) {
@@ -84,14 +89,12 @@ module.exports = async function wpExtract({
     fse.emptyDirSync(outputDir);
   } else {
     if (fs.existsSync(outputDir) && !(await isDirEmpty(outputDir))) {
-      throw new Error(
-        `Output dir is not empty. Clear it first or use the --force option to override it.`
-      );
+      throw new Error(`Output dir is not empty. Clear it first or use the --force option to override it.`);
     }
   }
 
   const inputFileStat = fs.statSync(_inputFile);
-  const inputFile = await fs.promises.open(_inputFile, 'r');
+  const inputFile = await fs.promises.open(_inputFile, "r");
 
   // Trigger onStart callback
   onStart(inputFileStat.size);

--- a/lib/wpress-extract.js
+++ b/lib/wpress-extract.js
@@ -49,14 +49,22 @@ async function readHeader(fd) {
   };
 }
 
-async function readBlockToFile(fd, header, outputPath) {
+async function readBlockToFile(fd, header, outputPath, ignoreWriteErrors) {
   const outputFilePath = path.join(
     outputPath,
     convertToValidWindowsFilepath(header.prefix),
     convertToValidWindowsFilename(header.name)
   );
   fse.ensureDirSync(path.dirname(outputFilePath));
+
   const outputStream = fs.createWriteStream(outputFilePath);
+  let writeError = null;
+  if (ignoreWriteErrors) {
+    outputStream.on('error', (err) => {
+      console.error(outputFilePath, err);
+      writeError = err;
+    });
+  }
 
   let totalBytesToRead = header.size;
   while (true) {
@@ -76,31 +84,47 @@ async function readBlockToFile(fd, header, outputPath) {
     totalBytesToRead -= data.bytesRead;
   }
 
-  outputStream.close();
+  return ignoreWriteErrors
+    ? new Promise((done, reject) =>
+        outputStream.close((err) =>
+          writeError ?? err ? reject(writeError ?? err) : done()
+        )
+      )
+    : outputStream.close();
 }
 
-module.exports = async function wpExtract({ inputFile: _inputFile, outputDir, onStart, onUpdate, onFinish, override }) {
+module.exports = async function wpExtract({
+  inputFile: _inputFile,
+  outputDir,
+  onStart,
+  onUpdate,
+  onFinish,
+  override,
+  ignoreWriteErrors,
+}) {
   if (!fs.existsSync(_inputFile)) {
-    throw new Error(`Input file at location "${_inputFile}" could not be found.`);
+    throw new Error(
+      `Input file at location "${_inputFile}" could not be found.`
+    );
   }
 
   if (override) {
     // Ensure the output dir exists and is empty
     fse.emptyDirSync(outputDir);
-  } else {
-    if (fs.existsSync(outputDir) && !(await isDirEmpty(outputDir))) {
-      throw new Error(`Output dir is not empty. Clear it first or use the --force option to override it.`);
-    }
+  } else if (fs.existsSync(outputDir) && !(await isDirEmpty(outputDir))) {
+    throw new Error(
+      `Output dir is not empty. Clear it first or use the --force option to override it.`
+    );
   }
 
   const inputFileStat = fs.statSync(_inputFile);
-  const inputFile = await fs.promises.open(_inputFile, "r");
+  const inputFile = await fs.promises.open(_inputFile, 'r');
 
   // Trigger onStart callback
   onStart(inputFileStat.size);
 
   let offset = 0;
-  let countFiles = 0;
+  const counts = { success: 0, error: 0 };
 
   while (true) {
     const header = await readHeader(inputFile);
@@ -108,9 +132,17 @@ module.exports = async function wpExtract({ inputFile: _inputFile, outputDir, on
       break;
     }
 
-    await readBlockToFile(inputFile, header, outputDir);
-    offset = offset + HEADER_SIZE + header.size;
-    countFiles++;
+    try {
+      await readBlockToFile(inputFile, header, outputDir, ignoreWriteErrors);
+      counts.success++;
+    } catch (err) {
+      if (!ignoreWriteErrors) {
+        throw err;
+      }
+      console.error(err);
+      counts.error++;
+    }
+    offset += HEADER_SIZE + header.size;
 
     // Trigger onUpdate callback
     onUpdate(offset);
@@ -119,5 +151,5 @@ module.exports = async function wpExtract({ inputFile: _inputFile, outputDir, on
   await inputFile.close();
 
   // Trigger onFinish callback
-  onFinish(countFiles);
+  onFinish(counts);
 };


### PR DESCRIPTION
First of all thanks for this great project ❤️, it helped me with client.

I found a couple of issues and fixed them:

- `--force` is now working (missing variable)
- if a linux backup is extraced on windows, there could be the issue (which I faced) that some filenames are invalid.
  - for example `somelog-00:00.log` and the whole extract process would fail
  - therefore I added a filename & filepath fix for windows to remove invalid characters
- I also added a general `--ignore-write-errors` option in case there are some other issues.
  - This allows at least to get all other files except of the faulty ones

some trivial code refactoring and added `.editorconfig`